### PR TITLE
Belt troughput speeds for 0.17 (#96)

### DIFF
--- a/src/app/views/cheat-sheets/belt-throughput/belt-throughput.component.html
+++ b/src/app/views/cheat-sheets/belt-throughput/belt-throughput.component.html
@@ -3,7 +3,7 @@
         <strong><a href="https://wiki.factorio.com/Transport_belt" target="_blank" rel="noopener">Transport Belt</a> Throughput</strong> - Items per second (i/s) passed over one belt tile.
     </p>
     <p class="card-text">
-        <strong>Transport Belt Density</strong> - Maximum Items fit in one tile. (<strong>7.11 items</strong> for all belts)
+        <strong>Transport Belt Density</strong> - Maximum Items fit in one tile. (<strong>8 items</strong> for all belts)
     </p>
     <p class="card-text">
         <strong>Note: </strong>
@@ -44,8 +44,7 @@
         </div>
 
         <div class="col-12 col-md-6 text-center">
-            <p>All belts can hold up to <strong>7.11 items</strong> on each tile<br>
-                (In game oscillates b/w 6 and 8)
+            <p>All belts can hold up to <strong>8 items</strong> on each tile.
             </p>
             <img src="{{APP_SETTINGS.links.getLocalImagePath('belt-signal-circuit.jpg')}}" class="img-fluid rounded" alt="Transport Belt Signal" title="Transport Belt Signal">
         </div>

--- a/src/assets/data/belt-throughput.json
+++ b/src/assets/data/belt-throughput.json
@@ -11,7 +11,7 @@
                 "Underground_belt",
                 "Splitter"
             ],
-            "throughput": 13.33333,
+            "throughput": 15,
             "multiplier": 1
         },
         {
@@ -21,7 +21,7 @@
                 "Fast_underground_belt",
                 "Fast_splitter"
             ],
-            "throughput": 26.6666,
+            "throughput": 30,
             "multiplier": 2
         },
         {
@@ -31,7 +31,7 @@
                 "Express_underground_belt",
                 "Express_splitter"
             ],
-            "throughput": 40,
+            "throughput": 45,
             "multiplier": 3
         }
     ]


### PR DESCRIPTION
Throughput is 15 for yellow, 30 for red, 45 for blue.
https://wiki.factorio.com/Tutorial:Cheat_sheet#Belt_throughput