### PR TITLE
Grammar/spelling.

### DIFF
--- a/src/app/views/cheat-sheets/belt-throughput/belt-throughput.component.html
+++ b/src/app/views/cheat-sheets/belt-throughput/belt-throughput.component.html
@@ -6,7 +6,7 @@
         <strong>Transport Belt Density</strong> - Maximum items that fit in one tile: <strong>8 items</strong> for all belts.
     </p>
     <p class="card-text">
-        <strong>Note: </strong> A
+        <strong>Note: </strong>
         <kbd class="txt-factorio-red">Red belt</kbd> is exactly twice as fast as a
         <kbd class="txt-factorio-yellow">Yellow belt</kbd>, and a
         <kbd class="txt-factorio-blue">Blue belt</kbd> is exactly three times as fast a

--- a/src/app/views/cheat-sheets/belt-throughput/belt-throughput.component.html
+++ b/src/app/views/cheat-sheets/belt-throughput/belt-throughput.component.html
@@ -3,7 +3,7 @@
         <strong><a href="https://wiki.factorio.com/Transport_belt" target="_blank" rel="noopener">Transport Belt</a> Throughput</strong> - Items per second (i/s) passed over one belt tile.
     </p>
     <p class="card-text">
-        <strong>Transport Belt Density</strong> - A maximum of <strong>8 items</strong> can fit on any belt.
+        <strong>Transport Belt Density</strong> - Maximum items that fit in one tile: <strong>8 items</strong> for all belts.
     </p>
     <p class="card-text">
         <strong>Note: </strong> A

--- a/src/app/views/cheat-sheets/belt-throughput/belt-throughput.component.html
+++ b/src/app/views/cheat-sheets/belt-throughput/belt-throughput.component.html
@@ -3,10 +3,10 @@
         <strong><a href="https://wiki.factorio.com/Transport_belt" target="_blank" rel="noopener">Transport Belt</a> Throughput</strong> - Items per second (i/s) passed over one belt tile.
     </p>
     <p class="card-text">
-        <strong>Transport Belt Density</strong> - Maximum Items fit in one tile. (<strong>8 items</strong> for all belts)
+        <strong>Transport Belt Density</strong> - A maximum of <strong>8 items</strong> can fit on any belt.
     </p>
     <p class="card-text">
-        <strong>Note: </strong>
+        <strong>Note: </strong> A
         <kbd class="txt-factorio-red">Red belt</kbd> is exactly twice as fast as a
         <kbd class="txt-factorio-yellow">Yellow belt</kbd>, and a
         <kbd class="txt-factorio-blue">Blue belt</kbd> is exactly three times as fast a


### PR DESCRIPTION
Changed line for Transport Belt density. I think this looks cleaner without the ( )

Added a "A" after Note. So that the section reads:
>A Red belt is exactly twice as fast as a Yellow belt, and a Blue belt is exactly three times as fast a Yellow belt.