### PR TITLE
Combine Stone with the other ores that have the same mining rate.

### DIFF
--- a/src/assets/data/mining.json
+++ b/src/assets/data/mining.json
@@ -8,7 +8,8 @@
             "materials": [
                 "Copper_ore",
                 "Iron_ore",
-                "Coal"
+                "Coal",
+                "Stone"
             ],
             "miningRate": {
                 "miner": "Burner_mining_drill",
@@ -22,30 +23,7 @@
             "materials": [
                 "Copper_ore",
                 "Iron_ore",
-                "Coal"
-            ],
-            "miningRate": {
-                "miner": "Electric_mining_drill",
-                "rate": 0.5
-            },
-            "beltYellow": 30,
-            "beltRed": 60,
-            "beltBlue": 90
-        },
-        {
-            "materials": [
-                "Stone"
-            ],
-            "miningRate": {
-                "miner": "Burner_mining_drill",
-                "rate": 0.25
-            },
-            "beltYellow": 60,
-            "beltRed": 120,
-            "beltBlue": 180
-        },
-        {
-            "materials": [
+                "Coal",
                 "Stone"
             ],
             "miningRate": {


### PR DESCRIPTION
The mining rate of stone was changed in 0.17 to be the same as iron, copper, and coal. This change removes the stone only row.