### PR TITLE
Add link to calculatorio for train acceleration/top speed

### DIFF
--- a/src/assets/data/links.json
+++ b/src/assets/data/links.json
@@ -93,7 +93,7 @@
                     },
                     {
                         "url": "https://calculatorio.com/train_acceleration/",
-                        "text": "Calculatorio train acceleration and top speed calculator"
+                        "text": "Calculatorio Train Acceleration and Top Speed Calculator"
                     }
                 ]
             },

--- a/src/assets/data/links.json
+++ b/src/assets/data/links.json
@@ -90,6 +90,10 @@
                     {
                         "url": "https://deniszholob.github.io/factorio-machine-ratio-calc/",
                         "text": "Generic Ratio Calculator"
+                    },
+                    {
+                        "url": "https://calculatorio.com/train_acceleration/",
+                        "text": "Calculatorio train acceleration and top speed calculator"
                     }
                 ]
             },


### PR DESCRIPTION
This PR adds the link to calculatorio, on the page for train acceleration/top speed.

Helps with issue #180.