### PR TITLE
Two small fixes for issue 180

### DIFF
--- a/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.html
+++ b/src/app/views/cheat-sheets/nuclear-power/nuclear-power.component.html
@@ -206,7 +206,7 @@
     Power (even config) = [Reactor Power * 4 * reactors] - [Reactor Power * 4]
     </kbd></p>
     <p><kbd>
-    Turbines = [Heat Exchangers * Heat Exchanger Power(10MW)] / [Turbine Power(5.8MW)]
+    Turbines = [Heat Exchangers * Heat Exchanger Power(10MW)] / [Turbine Power(5.82MW)]
     </kbd></p>
     <p><kbd>
     Pumps = [Turbines] * [Water Per Turbine / Water Per Pump]

--- a/src/app/views/cheat-sheets/tips/tips.component.html
+++ b/src/app/views/cheat-sheets/tips/tips.component.html
@@ -83,6 +83,8 @@
         </li>
         <li>
             Rich text "<i>[item=iron-plate]</i>" is displayed as the iron plate icon.
+            <br> To quickly get a rich text tag for an item: open the console, then shift-click on the item (eg in your inventory, a chest, etc.)
+            <br> A rich text tag for that item appears in the console and can be copied.
         </li>
         <li>
             <a href="https://www.reddit.com/r/factorio/comments/8zvbfn/til_you_can_display_signal_states_on_the_map/" target="_blank" rel="noopener">


### PR DESCRIPTION
Add section on rich text shortcut: To quickly get a rich text tag for an item: open the console, then shift-click on the item (eg in your inventory, a chest, etc.) A rich text tag for that item appears in the console and can be copied.
and
Nuke Turbines formula 5.8MW => 5.82MW