### PR TITLE
Tiny grammar fix + updated stackinserter amount

### DIFF
--- a/src/app/views/cheat-sheets/inserter-throughput/inserter-throughput.component.html
+++ b/src/app/views/cheat-sheets/inserter-throughput/inserter-throughput.component.html
@@ -79,7 +79,7 @@
             Taking items from belts is slightly slower than placing them.
         </li>
         <li>
-            It takes ~1.5 stack inserters (exclusive swinging time) to fill half a blue belt.
+            It takes ~2.7 stack inserters (excluding swinging time) to fill half a blue belt.
         </li>
         <li>
             As always check the <a href="https://wiki.factorio.com/Inserters#Inserter_Throughput" target="_blank" rel="noopener">Wiki</a> for more in depth information.


### PR DESCRIPTION
1) Tiny grammar fix
2) number fix: (blue belt speed changed)
Inserters Required = (Target Item Rate) / (Inserter Throughput)
stated speed stack inserter = 13.85 i/s
stated blue belt speed = 45 1/s
Ir = 45/13.85=2.6706231454 so rounded up to 1 digit ~2.7

PS: (I have not verified the speed of the inserter in-game for myself, I assumed the number on the page is the right one)