### PR TITLE
Closes #229 - problem with Jura font-weight 700

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -64,7 +64,7 @@
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Play" rel="stylesheet" type="text/css">
-    <link href="https://fonts.googleapis.com/css?family=Jura" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css2?family=Jura:wght@400;700" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css"
         integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
 


### PR DESCRIPTION
Currently the Jura font at weight `700` is rendered incorrectly on some browsers, as per issue #229. This is due to the web font at this weight not being requested from Google Fonts. This PR  specifies the web font weights we need from Google fonts, and fixes the issue.

**Screenshot before:** 
<img width="226" alt="Screen Shot 2020-06-07 at 16 19 01" src="https://user-images.githubusercontent.com/1420253/83973089-e286a300-a8db-11ea-9247-b36046faa58f.png">

**Screenshot after**
<img width="209" alt="Screen Shot 2020-06-07 at 16 19 27" src="https://user-images.githubusercontent.com/1420253/83973116-1cf04000-a8dc-11ea-8956-f3372dae9c1a.png">

(Screenshots are a little blurry due to being taken on browserstack in mac, but I've also tested the fix on Windows machine and looks even better 👍 )