### PR TITLE
Enable Dependabot for this repo, to help with dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily" # On weekdays, check if there are updates.


### PR DESCRIPTION
Hi @deniszholob,

Keeping track of dependency updates is no fun! But there's a official GitHub created/approved bot to keep track of `npm` updates for us, it's called: **Dependabot**.

Benefits:
- The bot keeps track of any security/normal updates.
- You'll get one pull-request per dependency, so you can hold back any updates that break the build.
- The bot links to the change-log for the dependency, so that you can check what has changed, and if there's anything you'll need to do manually before merging.
- Keeping up to date with dependencies keeps changes small, and prevents big headaches down the line.
- When there are confidence giving tests (which I will help create if you want), you can only allow merges that will keep the build in a working state. This way if the tests pass, you can just say: "Hey the tests all work, lets merge that update from Dependabot, and be done with it!"
- To prevent you from getting overwhelmed after turning Dependabot on, it will limit itself to 5 pull-requests at max, until we're fully up-to-date.
- You can select how often Dependabot checks for updates (weekdays, weekly, monthly)

Drawbacks:
- It will be a bit of work to get all the dependencies up to date. But this work should be done anyways, as otherwise the project will be insecure or get really hard to update later.

---

## What will happen when you merge this pull-request?

What merging this pull-request will do:
- Enable the **Dependabot** dependency management bot for this repository.
- On weekdays (Monday through Driday), Dependabot will check if there are updates for any dependencies listed in the `package.json` and `package-lock.json` files, and create individual pull-requests per dependency with the updated `package.json` / `package-lock.json`.

---

## Documentation for Dependabot:
https://help.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically

---

## Discussion:

I really, really recommend using Dependabot! I enable it on all my repos, both private and public. It takes away a lot of the stress of manually managing updates.