### PR TITLE
Docs: bump to latest NodeJS LTS (12.18.2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## What you will need before you begin:
 
-1. Ensure NodeJS version 12.16.3 LTS is installed on your system.
+1. Ensure NodeJS version 12.18.2 LTS is installed on your system.
 2. Clone the repository.
 3. Run `npm install` in the folder that you've just cloned to ensure you have all dependencies that are needed for development.
 


### PR DESCRIPTION
This pull request updates the `contributing.md` file so that we refer to the latest NodeJS LTS version.

---

Edit: this is was a bit premature. Because we're still using the outdated NodeJS LTS in the package.json and Travis CI configuration. I'll make a pull-request that updates all those things in one go....