### PR TITLE
Bump NodeJS to latest LTS (12.18.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
 
 language: node_js # Building with node js
 node_js:
-    - 12.16.3 # Same node version as package.json
+    - 12.18.2 # Same node version as package.json
 
 # Blocklist
 branches:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## What you will need before you begin:
 
-1. Ensure NodeJS version 12.16.3 LTS is installed on your system.
+1. Ensure NodeJS version 12.18.2 LTS is installed on your system.
 2. Clone the repository.
 3. Run `npm install` in the folder that you've just cloned to ensure you have all dependencies that are needed for development.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "private": true,
   "engines": {
-    "node": ">= 12.16.3",
+    "node": ">= 12.18.2",
     "npm": ">= 6.13.4"
   },
   "lint-staged": {


### PR DESCRIPTION
This pull-request will update to the latest NodeJS LTS version in:
- `package.json`
- `.travis.yml`
- `CONTRIBUTING.md`

---

EDIT: I noticed that the Travis CI run for this pull-request is using the proposed NodeJS LTS (12.18.2) version, and the build is passing on Travis, as well as locally on my Linux machine.