### PR TITLE
Change Factorio version 1.0 -> 1.0.0

### DIFF
--- a/src/app/shared/app-settings.ts
+++ b/src/app/shared/app-settings.ts
@@ -15,7 +15,7 @@ export const APP_SETTINGS: AppInfo = {
         name: 'Github Source',
         url: 'https://github.com/deniszholob/factorio-cheat-sheet',
     },
-    data_version: '1.0',
+    data_version: '1.0.0',
     // languages: ['en-US'],
     links: {
         getLocalImagePath: function (imageName) {


### PR DESCRIPTION
This is a really minor nitpick, it should be 1.0.0
The Factorio versioning scheme is: _major.minor.patch._

The [Factorio home page](https://factorio.com/) has the latest stable release listed as: 1.0.0
It's also 1.0.0 in-game in the about part of the main menu.