### PR TITLE
Add efficiency module train colour.

### DIFF
--- a/src/assets/data/train-colors.json
+++ b/src/assets/data/train-colors.json
@@ -186,6 +186,10 @@
                 "rgb": [0, 0, 18]
             },
             {
+                "icon": "Efficiency_module",
+                "rgb": [88, 132, 53]
+            },
+            {
                 "icon": "Electric_engine_unit",
                 "rgb": [109, 76, 79]
             },


### PR DESCRIPTION
I noticed this was missing during my current play through.
I grabbed the colour from an image on the main Factorio site.