### PR TITLE
Update tip: Blueprints in map view

### DIFF
--- a/src/app/views/cheat-sheets/tips/tips.component.html
+++ b/src/app/views/cheat-sheets/tips/tips.component.html
@@ -138,7 +138,7 @@
             Fluids can move through boilers, tanks,
             and electric mining drills (only when mining uranium).
         </li>
-        <li>Blueprints can be used from map view on a revealed area of the map (near the player or by radar).
+        <li>Blueprints can be used from map view.
         </li>
     </ul>
 


### PR DESCRIPTION
Blueprints in map view are no longer limited to radar coverage.  (As of 1.1 you'll be able to create a blueprint, deconstruct, and cut/copy without coverage as well, but that's not mentioned here anyway.)