### PR TITLE
Style Tweaks

### DIFF
--- a/src/app/views/cheat-sheets/links/links.data.ts
+++ b/src/app/views/cheat-sheets/links/links.data.ts
@@ -77,16 +77,6 @@ export const LINKS_DATA: RawData<LinksData> = {
             caption: 'If you dare',
           },
           {
-            url: 'https://factorioprints.com/top',
-            text: 'Blueprint Library',
-            caption: 'Top community designs.',
-          },
-          {
-            url: 'https://factorioblueprints.tech/',
-            text: 'Another Blueprint Library',
-            caption: 'More community designs.',
-          },
-          {
             url: 'https://factorio.zone/',
             text: 'Factorio Zone',
             caption: 'Easy online servers',
@@ -95,11 +85,6 @@ export const LINKS_DATA: RawData<LinksData> = {
             url: 'https://hub.docker.com/r/factoriotools/factorio',
             text: 'Docker',
             caption: 'Easy headless servers',
-          },
-          {
-            url: 'https://factoriomaps.com/',
-            text: 'Maps',
-            caption: 'View/Download Maps',
           },
           {
             url: 'https://www.speedrun.com/Factorio/resources',
@@ -230,6 +215,23 @@ export const LINKS_DATA: RawData<LinksData> = {
           {
             url: 'https://www.reddit.com/r/factorio/comments/4f38sk/factorio_train_automation_complete_parts_23_and/',
             text: 'Train Automation',
+          },
+        ],
+      },
+      {
+        text: 'Designs',
+        links: [
+          {
+            url: 'https://factoriomaps.com/',
+            text: 'View/Download Maps',
+          },
+          {
+            url: 'https://factorioblueprints.tech/',
+            text: 'Factorio Blueprints .tech',
+          },
+          {
+            url: 'https://factorioprints.com/top',
+            text: 'Factorio Prints .com',
           },
         ],
       },

--- a/src/app/views/cheat-sheets/material-processing/material-processing.component.html
+++ b/src/app/views/cheat-sheets/material-processing/material-processing.component.html
@@ -4,11 +4,8 @@
       <table class="table table-sm table-hover table-bordered">
         <thead class="text-center">
           <tr>
-            <th colspan="2">
-              Buildings needed<a href="#note_building_processing">^</a>
-              to
-            </th>
-            <th colspan="3">Empty Input Belt</th>
+            <th colspan="2">Factories needed<a href="#note_building_processing">^</a> to</th>
+            <th colspan="3">Empty input belt</th>
           </tr>
           <tr>
             <th>With</th>
@@ -32,15 +29,9 @@
             <td *ngIf="idx % 2 === 0" rowspan="2">
               <app-factorio-icon *ngFor="let iconId of item?.material" [icon]="dataService.getFactorioIcon(iconId)"></app-factorio-icon>
             </td>
-            <td class="bg-input">
-              {{ item?.beltYellow }}
-            </td>
-            <td class="bg-input">
-              {{ item?.beltRed }}
-            </td>
-            <td class="bg-input">
-              {{ item?.beltBlue }}
-            </td>
+            <td class="bg-input" title="Factories">{{ item?.beltYellow }}</td>
+            <td class="bg-input" title="Factories">{{ item?.beltRed }}</td>
+            <td class="bg-input" title="Factories">{{ item?.beltBlue }}</td>
           </tr>
         </tbody>
       </table>
@@ -50,11 +41,8 @@
       <table class="table table-sm table-hover table-bordered">
         <thead class="text-center">
           <tr>
-            <th colspan="2">
-              Buildings needed<a href="#note_building_processing">^</a>
-              to
-            </th>
-            <th colspan="3">Fill Output Belt</th>
+            <th colspan="2">Factories needed<a href="#note_building_processing">^</a> to</th>
+            <th colspan="3">Fill output belt</th>
           </tr>
           <tr>
             <th>With</th>
@@ -78,22 +66,16 @@
             <td *ngIf="idx % 2 === 0" rowspan="2">
               <app-factorio-icon *ngFor="let iconId of item?.material" [icon]="dataService.getFactorioIcon(iconId)"></app-factorio-icon>
             </td>
-            <td class="bg-output">
-              {{ item?.beltYellow }}
-            </td>
-            <td class="bg-output">
-              {{ item?.beltRed }}
-            </td>
-            <td class="bg-output">
-              {{ item?.beltBlue }}
-            </td>
+            <td class="bg-output" title="Factories">{{ item?.beltYellow }}</td>
+            <td class="bg-output" title="Factories">{{ item?.beltRed }}</td>
+            <td class="bg-output" title="Factories">{{ item?.beltBlue }}</td>
           </tr>
         </tbody>
       </table>
     </div>
   </div>
 
-  <p class="text-muted" id="note_building_processing">^Buildings are rounded up to the nearest whole number.</p>
+  <p class="text-muted" id="note_building_processing">^Factories are rounded up to the nearest whole number.</p>
 
   <hr />
 
@@ -160,7 +142,7 @@
         </tbody>
       </table>
       <p class="text-center">
-        <kbd>Buildings = Belt Throughput / Material Consumption Rate</kbd>
+        <kbd>Factories = Belt Throughput / Material Consumption Rate</kbd>
       </p>
     </div>
   </div>

--- a/src/app/views/nav/nav.component.html
+++ b/src/app/views/nav/nav.component.html
@@ -1,6 +1,6 @@
 <div class="side-nav" id="mySidenav" [class.open]="isNavOpen">
   <div class="nav-header">
-    <a class="close-btn" [class.d-none]="doKeepOpen()" (click)="closeNav()" href="javascript:void(0)">&times;</a>
+    <!-- <a class="close-btn" [class.d-none]="doKeepOpen()" (click)="closeNav()" href="javascript:void(0)">&times;</a> -->
     <div class="row">
       <div class="col-6 text-center">
         <button class="btn btn-primary" (click)="collapseAllSheets()">Collapse All</button>

--- a/src/styles/_side-nav.scss
+++ b/src/styles/_side-nav.scss
@@ -25,7 +25,7 @@ $nav-width: 250px;
 
   /* The navigation menu links */
   a {
-    padding: 8px 8px 8px 32px;
+    padding: 7px 8px 7px 32px;
     text-decoration: none;
     font-size: 18px;
     color: $c-pallette-text-muted;
@@ -48,13 +48,12 @@ $nav-width: 250px;
   .nav-header {
     position: sticky;
     top: 0;
-    padding: 5px 0;
+    padding: 4px 0;
   }
 
   .nav-contents {
     overflow-y: auto;
     overflow-x: hidden; // Disable horizontal scroll
-    margin-top: 5px;
   }
 }
 

--- a/src/styles/_switch.scss
+++ b/src/styles/_switch.scss
@@ -1,6 +1,6 @@
 // Ref: https://www.w3schools.com/howto/howto_css_switch.asp
-$s-width: 60px;
-$s-height: #{$s-width/2.5 - 2px};
+$s-width: 50px;
+$s-height: calc(#{$s-width/2 - 2px});
 $s-border: 1px;
 
 $s-toggle-spacing: 4px;


### PR DESCRIPTION
* Decrease nav padding slightly to remove scrollbars on 1080p screens and larger
* Comment out the nav close button to save vertical space as there is the arrow does the same thing
* Tweak switch styles to make it less long and address division without calc() deprecation notice
* Move blueprint + map links to own designs category
* closes #337 add titles for material processing cell and rename buildings to factories