### PR TITLE
#235 cheat sheet categories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,9 @@ build
 coverage
 
 *.mdx
+
+# Misc
+/DEV
+/node_modules
+package-lock.json
+/.angular

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div id="#Top"></div>
+<div id="Top"></div>
 
 <app-nav></app-nav>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,5 @@
 // Angular
-import { AfterViewChecked, Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
+import { Component, OnDestroy } from '@angular/core';
 
 // PWA
 import {
@@ -10,73 +9,20 @@ import {
 } from '@angular/service-worker';
 import { filter, map, Subject, takeUntil } from 'rxjs';
 
-// Ongoing Angular issue with scrolling to anchor elements: https://github.com/angular/angular/issues/6595
-// Modified Solution (ngOnInit() and ngAfterVewInit()) from the issues page and https://stackoverflow.com/questions/36101756/angular2-routing-with-hashtag-to-page-anchor
-
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  // styleUrls: ['./app.component.scss'] // Enable as needed
 })
-export class AppComponent implements OnDestroy, OnInit, AfterViewChecked {
+export class AppComponent implements OnDestroy {
   private readonly clearSub$ = new Subject<void>();
 
-  private fragment: string = '';
-  private scrolled: boolean = false;
-
-  constructor(
-    private route: ActivatedRoute,
-    private swUpdate: SwUpdate,
-    private router: Router
-  ) {
+  constructor(private swUpdate: SwUpdate) {
     this.subToUpdateApp();
-    // Ref: https://www.bennadel.com/blog/3533-using-router-events-to-detect-back-and-forward-browser-navigation-in-angular-7-0-4.htm
-    this.router.events
-      .pipe(
-        takeUntil(this.clearSub$),
-        filter(
-          (event): event is NavigationStart => event instanceof NavigationStart
-        )
-      )
-      .subscribe((event: NavigationStart) => {
-        // User uses browser navigation (back/forward)
-        if (event.navigationTrigger === 'popstate') {
-          this.scrolled = false;
-        }
-      });
-  }
-
-  ngOnInit(): void {
-    this.route.fragment
-      .pipe(takeUntil(this.clearSub$))
-      .subscribe((fragment: string | null) => {
-        this.fragment = fragment ?? '';
-      });
-  }
-
-  /**
-   * This will execute each time after every view is loaded
-   * Only need one correct view to load then stop trying to scroll
-   * Catch any invalid views.
-   */
-  ngAfterViewChecked(): void {
-    if (!this.scrolled) {
-      this.scrollIntoView();
-    }
   }
 
   ngOnDestroy(): void {
     this.clearSub$.next();
     this.clearSub$.complete();
-  }
-
-  private scrollIntoView(): void {
-    try {
-      document.querySelector('#' + this.fragment)?.scrollIntoView();
-      this.scrolled = true;
-    } catch (e) {
-      // Ignore any invalid tries
-    }
   }
 
   /** Service worker auto refresh the page if new version available */

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,16 +10,12 @@ import * as Services from 'app/services';
 
 // Components
 import { AppComponent } from 'app/app.component';
-import * as ViewComponents from 'app/layout';
-import { FactorioIconModule, RatioModule } from 'app/shared';
-import { MainModule } from './layout/main/main.module';
-import { AdSenseModule } from './shared/ad-sense/ad-sense.module';
-import { CheatSheetModule } from './shared/cheat-sheet/cheat-sheet.module';
 import { LayoutModule } from './layout/layout.module';
+import { AdSenseModule } from './shared/ad-sense/ad-sense.module';
 
 const ROUTER_OPTIONS: ExtraOptions = {
-  // anchorScrolling: 'enabled', // Doesn't work with href="#something" but rather with [routerLink]="['./']" [fragment]="something"
-  // scrollPositionRestoration: 'enabled', // Works with anchorScrolling only
+  anchorScrolling: 'enabled', // Doesn't work with href="#something" but rather with [routerLink]="['./']" [fragment]="something"
+  scrollPositionRestoration: 'enabled', // Works with anchorScrolling only
   // useHash: true,
 };
 @NgModule({
@@ -36,17 +32,11 @@ const ROUTER_OPTIONS: ExtraOptions = {
       // registrationStrategy: 'registerWhenStable:30000' // Default, so commenting out
     }),
 
-    // Local - Shared
-    AdSenseModule,
-    FactorioIconModule,
-    RatioModule,
-    CheatSheetModule,
-    // Local - Layouts
+    // Local
     LayoutModule,
+    AdSenseModule,
   ],
-  // Components
   declarations: [AppComponent],
-  // Services
   providers: [Services.DataService, Services.SheetCollapseToggleService],
   bootstrap: [AppComponent],
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,7 +14,7 @@ import { LayoutModule } from './layout/layout.module';
 import { AdSenseModule } from './shared/ad-sense/ad-sense.module';
 
 const ROUTER_OPTIONS: ExtraOptions = {
-  anchorScrolling: 'enabled', // Doesn't work with href="#something" but rather with [routerLink]="['./']" [fragment]="something"
+  anchorScrolling: 'enabled', // Doesn't work with href="#something" but rather with [routerLink]="[]" [fragment]="something"
   scrollPositionRestoration: 'enabled', // Works with anchorScrolling only
   // useHash: true,
 };

--- a/src/app/cheat-sheets/cheat-sheets.module.ts
+++ b/src/app/cheat-sheets/cheat-sheets.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { GameBaseModule } from './game-base/game-base.module';
+import { GameModsModule } from './game-mods/game-mods.module';
+
+import { ROOT_GAME_BASE } from './game-base/game-base.routes';
+import { ROOT_GAME_MODS } from './game-mods/game-mods.routes';
+
+export const CHEAT_SHEET_CATEGORIES = {
+  [ROOT_GAME_BASE]: 'Factorio Base',
+  [ROOT_GAME_MODS]: 'Factorio Mods',
+} as const;
+
+export type CheatSheetCategory = keyof typeof CHEAT_SHEET_CATEGORIES;
+
+@NgModule({
+  exports: [GameBaseModule, GameModsModule],
+})
+export class CheatSheetsModule {}

--- a/src/app/cheat-sheets/game-base/cargo-wagon-transfer/cargo-wagon-transfer.component.html
+++ b/src/app/cheat-sheets/game-base/cargo-wagon-transfer/cargo-wagon-transfer.component.html
@@ -31,7 +31,7 @@
               <app-factorio-icon [icon]="dataService.getFactorioIcon('Crude_oil_barrel')"></app-factorio-icon>
               <br />
               <span
-                ><a href="#note_wagon_transfer_barrel">*</a>
+                ><a [routerLink]="[]" fragment="note_wagon_transfer_barrel">*</a>
                 10 items
                 <br />
                 per stack</span

--- a/src/app/cheat-sheets/game-base/cargo-wagon-transfer/cargo-wagon-transfer.module.ts
+++ b/src/app/cheat-sheets/game-base/cargo-wagon-transfer/cargo-wagon-transfer.module.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { FactorioIconModule } from 'app/shared';
 import { CheatSheetModule } from 'app/shared/cheat-sheet/cheat-sheet.module';
 
 import { CargoWagonTransferComponent } from './cargo-wagon-transfer.component';
 
 @NgModule({
-  imports: [CommonModule, CheatSheetModule, FactorioIconModule],
+  imports: [CommonModule, RouterModule, CheatSheetModule, FactorioIconModule],
   declarations: [CargoWagonTransferComponent],
   exports: [CargoWagonTransferComponent],
 })

--- a/src/app/cheat-sheets/game-base/cs-common-ratios/cs-common-ratios.component.html
+++ b/src/app/cheat-sheets/game-base/cs-common-ratios/cs-common-ratios.component.html
@@ -15,7 +15,7 @@
     </span>
   </p>
 
-  <p>Go to the <a href="#links">links</a> section of this page, for blueprints and calculators.</p>
+  <p>Go to the <a [routerLink]="[]" fragment="links">links</a> section of this page, for blueprints and calculators.</p>
 
   <div class="row">
     <div class="col-12 col-md-6 mb-10" *ngFor="let item of COMMON_RATIO_DATA">

--- a/src/app/cheat-sheets/game-base/cs-common-ratios/cs-common-ratios.module.ts
+++ b/src/app/cheat-sheets/game-base/cs-common-ratios/cs-common-ratios.module.ts
@@ -3,10 +3,12 @@ import { CommonModule } from '@angular/common';
 import { CsCommonRatiosComponent } from './cs-common-ratios.component';
 import { CheatSheetTemplateModule } from 'app/shared/cheat-sheet-template/cheat-sheet-template.module';
 import { FactorioIconModule, RatioModule } from 'app/shared';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   imports: [
     CommonModule,
+    RouterModule,
     CheatSheetTemplateModule,
     RatioModule,
     FactorioIconModule,

--- a/src/app/cheat-sheets/game-base/fluid-wagon-transfer/fluid-wagon-transfer.component.html
+++ b/src/app/cheat-sheets/game-base/fluid-wagon-transfer/fluid-wagon-transfer.component.html
@@ -86,7 +86,7 @@
   <div class="row align-items-center justify-content-around">
     <div class="col text-center col-print-3">
       <span
-        ><strong>Tanker-Pump Alignment <a href="#note-alignment">*</a></strong></span
+        ><strong>Tanker-Pump Alignment <a [routerLink]="[]" fragment="note-alignment">*</a></strong></span
       ><br />
       <video
         class="img-fluid rounded"

--- a/src/app/cheat-sheets/game-base/fluid-wagon-transfer/fluid-wagon-transfer.module.ts
+++ b/src/app/cheat-sheets/game-base/fluid-wagon-transfer/fluid-wagon-transfer.module.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { FactorioIconModule } from 'app/shared';
 import { CheatSheetModule } from 'app/shared/cheat-sheet/cheat-sheet.module';
 
 import { FluidWagonTransferComponent } from './fluid-wagon-transfer.component';
 
 @NgModule({
-  imports: [CommonModule, CheatSheetModule, FactorioIconModule],
+  imports: [CommonModule, RouterModule, CheatSheetModule, FactorioIconModule],
   declarations: [FluidWagonTransferComponent],
   exports: [FluidWagonTransferComponent],
 })

--- a/src/app/cheat-sheets/game-base/game-base.module.ts
+++ b/src/app/cheat-sheets/game-base/game-base.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 import { BalancersModule } from './balancers/balancers.module';
 import { BasicPowerModule } from './basic-power/basic-power.module';
@@ -8,6 +9,7 @@ import { CargoWagonTransferModule } from './cargo-wagon-transfer/cargo-wagon-tra
 import { CsCommonRatiosModule } from './cs-common-ratios/cs-common-ratios.module';
 import { FluidWagonTransferModule } from './fluid-wagon-transfer/fluid-wagon-transfer.module';
 import { GameBaseComponent } from './game-base.component';
+import { ROUTES_GAME_BASE } from './game-base.routes';
 import { InserterCapacityBonusModule } from './inserter-capacity-bonus/inserter-capacity-bonus.module';
 import { InserterThroughputModule } from './inserter-throughput/inserter-throughput.module';
 import { LinksModule } from './links/links.module';
@@ -25,6 +27,7 @@ import { VehicleFuelBonusModule } from './vehicle-fuel-bonus/vehicle-fuel-bonus.
 @NgModule({
   imports: [
     CommonModule,
+    RouterModule.forChild(ROUTES_GAME_BASE),
 
     // Sheets
     BalancersModule,

--- a/src/app/cheat-sheets/game-base/game-base.routes.ts
+++ b/src/app/cheat-sheets/game-base/game-base.routes.ts
@@ -1,0 +1,23 @@
+import { Routes } from '@angular/router';
+import { GameBaseComponent } from './game-base.component';
+
+export const ROOT_GAME_BASE = 'base';
+export const ROUTES_GAME_BASE: Routes = [
+  {
+    path: '',
+    children: [
+      {
+        path: ROOT_GAME_BASE,
+        component: GameBaseComponent,
+        data: {
+          label: '',
+        },
+      },
+      {
+        path: '',
+        redirectTo: ROOT_GAME_BASE,
+        pathMatch: 'full',
+      },
+    ],
+  },
+];

--- a/src/app/cheat-sheets/game-base/material-processing/material-processing.component.html
+++ b/src/app/cheat-sheets/game-base/material-processing/material-processing.component.html
@@ -4,7 +4,7 @@
       <table class="table table-sm table-hover table-bordered">
         <thead class="text-center">
           <tr>
-            <th colspan="2">Factories needed<a href="#note_building_processing">^</a> to</th>
+            <th colspan="2">Factories needed<a [routerLink]="[]" fragment="note_building_processing">^</a> to</th>
             <th colspan="3">Empty input belt</th>
           </tr>
           <tr>
@@ -41,7 +41,7 @@
       <table class="table table-sm table-hover table-bordered">
         <thead class="text-center">
           <tr>
-            <th colspan="2">Factories needed<a href="#note_building_processing">^</a> to</th>
+            <th colspan="2">Factories needed<a [routerLink]="[]" fragment="note_building_processing">^</a> to</th>
             <th colspan="3">Fill output belt</th>
           </tr>
           <tr>
@@ -169,7 +169,7 @@
         <i class="fas fa-long-arrow-alt-right text-muted"></i>
         <app-factorio-icon [icon]="dataService.getFactorioIcon('Uranium-235', 7)"></app-factorio-icon>
         <app-factorio-icon [icon]="dataService.getFactorioIcon('Uranium-238', 993)"></app-factorio-icon>
-        <a href="#note_uranium_processing_ratio">**</a>
+        <a [routerLink]="[]" fragment="note_uranium_processing_ratio">**</a>
       </p>
       <p class="text-center">
         <app-factorio-icon [icon]="dataService.getFactorioIcon('Uranium-235', 40)"></app-factorio-icon>

--- a/src/app/cheat-sheets/game-base/material-processing/material-processing.module.ts
+++ b/src/app/cheat-sheets/game-base/material-processing/material-processing.module.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { FactorioIconModule } from 'app/shared';
 import { CheatSheetModule } from 'app/shared/cheat-sheet/cheat-sheet.module';
 
 import { MaterialProcessingComponent } from './material-processing.component';
 
 @NgModule({
-  imports: [CommonModule, CheatSheetModule, FactorioIconModule],
+  imports: [CommonModule, RouterModule, CheatSheetModule, FactorioIconModule],
   declarations: [MaterialProcessingComponent],
   exports: [MaterialProcessingComponent],
 })

--- a/src/app/cheat-sheets/game-base/nuclear-power/nuclear-power.component.html
+++ b/src/app/cheat-sheets/game-base/nuclear-power/nuclear-power.component.html
@@ -13,7 +13,7 @@
     </p>
 
     <p class="col-12 col-sm-4 text-center">
-      <span class="text-muted">Common Build Ratio <a href="#note_build_ratios">^</a></span
+      <span class="text-muted">Common Build Ratio <a [routerLink]="[]" fragment="note_build_ratios">^</a></span
       ><br />
       <ng-container *ngFor="let item of sheetData?.commonRatio">
         <app-factorio-icon [icon]="dataService.getFactorioIcon(item?.iconId, item?.count)"></app-factorio-icon>
@@ -26,7 +26,7 @@
     </p>
 
     <p class="col-12 col-sm-4 text-center">
-      <span class="text-muted">Pump Ratio <a href="#note_build_ratios">^</a></span
+      <span class="text-muted">Pump Ratio <a [routerLink]="[]" fragment="note_build_ratios">^</a></span
       ><br />
       <ng-container *ngFor="let item of sheetData?.pumpRatio">
         <app-factorio-icon [icon]="dataService.getFactorioIcon(item?.iconId, item?.count)"></app-factorio-icon>
@@ -41,7 +41,7 @@
 
   <p class="text-muted text-center" id="note_build_ratios">
     <strong>^Note:</strong> Pumps, Steam Turbines and Power are approximate for easier build ratios. See
-    <a href="#nuclear-table">table below</a>
+    <a [routerLink]="[]" fragment="nuclear-table">table below</a>
     for precise numbers.
   </p>
 
@@ -131,7 +131,10 @@
   <hr />
   <div class="row">
     <div class="col-12 col-md-5 text-center">
-      <p><strong>Most efficient setup</strong><a href="#note_nuclear_effficient_setup">**</a>: a series of repeating 2x1 reactors</p>
+      <p>
+        <strong>Most efficient setup</strong><a [routerLink]="[]" fragment="note_nuclear_effficient_setup">**</a>: a series of repeating 2x1
+        reactors
+      </p>
       <img
         class="img-fluid rounded"
         src="{{ APP_SETTINGS.links.getLocalImagePath('nuclear-config-h.webp') }}"

--- a/src/app/cheat-sheets/game-base/nuclear-power/nuclear-power.module.ts
+++ b/src/app/cheat-sheets/game-base/nuclear-power/nuclear-power.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { FactorioIconModule } from 'app/shared';
 import { CheatSheetModule } from 'app/shared/cheat-sheet/cheat-sheet.module';
 import { NuclearPowerComponent } from './nuclear-power.component';
@@ -10,6 +11,7 @@ import { SreDiagramModule } from './sre-diagram/sre-diagram.module';
   imports: [
     CommonModule,
     FormsModule,
+    RouterModule,
 
     SreDiagramModule,
     FactorioIconModule,

--- a/src/app/cheat-sheets/game-base/oil-refining/oil-refining.component.html
+++ b/src/app/cheat-sheets/game-base/oil-refining/oil-refining.component.html
@@ -73,7 +73,7 @@
         >
           Moduled
         </a>
-        Cracking Ratio <a href="#note_oil_ratio">*</a>
+        Cracking Ratio <a [routerLink]="[]" fragment="note_oil_ratio">*</a>
       </span>
       <br />
 
@@ -112,7 +112,7 @@
       ~106 refineries
     </a>
     + respective cracking from 1 pipeline at
-    <a href="#fluid-flow-and-pipe-length">1200 oil/s</a>.
+    <a [routerLink]="[]" fragment="fluid-flow-and-pipe-length">1200 oil/s</a>.
     <br />
     You can supply
     <a
@@ -123,7 +123,7 @@
       ~23 moduled refineries
     </a>
     + respective cracking from 1 pipeline at
-    <a href="#fluid-flow-and-pipe-length">1200 oil/s</a>.
+    <a [routerLink]="[]" fragment="fluid-flow-and-pipe-length">1200 oil/s</a>.
   </p>
 
   <div class="row align-items-center">
@@ -262,7 +262,7 @@
         <a href="https://docs.google.com/spreadsheets/d/1Y6oL3Fl4P76_GAp6oNYDv9dXtjDKBE7xiUCtktTgFgY/" target="_blank" rel="noopener"
           >Moduled</a
         >
-        Cracking Ratio<a href="#note_oil_ratio">*</a> </span
+        Cracking Ratio<a [routerLink]="[]" fragment="note_oil_ratio">*</a> </span
       ><br />
       <app-icon-ratio-composite
         *ngFor="let item of sheetData?.moduledLiquefactionCrackingRatio"

--- a/src/app/cheat-sheets/game-base/oil-refining/oil-refining.module.ts
+++ b/src/app/cheat-sheets/game-base/oil-refining/oil-refining.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { FactorioIconModule } from 'app/shared';
 import { CheatSheetModule } from 'app/shared/cheat-sheet/cheat-sheet.module';
 import { IconRatioCompositeModule } from 'app/shared/icon-ratio-composite/icon-ratio-composite.module';
@@ -9,6 +10,7 @@ import { OilRefiningComponent } from './oil-refining.component';
 @NgModule({
   imports: [
     CommonModule,
+    RouterModule,
     CheatSheetModule,
     FactorioIconModule,
     IconRatioCompositeModule,

--- a/src/app/cheat-sheets/game-base/science/science.component.html
+++ b/src/app/cheat-sheets/game-base/science/science.component.html
@@ -51,7 +51,7 @@
   <ul>
     <li>
       Check the
-      <a href="#common-ratios">ratios for each science pack</a>.
+      <a [routerLink]="[]" fragment="common-ratios">ratios for each science pack</a>.
     </li>
     <li>
       Check your

--- a/src/app/cheat-sheets/game-base/science/science.module.ts
+++ b/src/app/cheat-sheets/game-base/science/science.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { FactorioIconModule } from 'app/shared';
 import { CheatSheetModule } from 'app/shared/cheat-sheet/cheat-sheet.module';
 import { IconRatioCompositeModule } from 'app/shared/icon-ratio-composite/icon-ratio-composite.module';
@@ -10,6 +11,7 @@ import { ScienceComponent } from './science.component';
 @NgModule({
   imports: [
     CommonModule,
+    RouterModule,
     FormsModule,
     CheatSheetModule,
     FactorioIconModule,

--- a/src/app/cheat-sheets/game-mods/game-mods.component.html
+++ b/src/app/cheat-sheets/game-mods/game-mods.component.html
@@ -1,0 +1,31 @@
+<app-cheat-sheet-template [iconId]="iconId" [title]="title">
+  <p class="lead">Wouldn't it be awesome to have cheat sheets for mods?</p>
+
+  Some of you thought so!
+  <br />
+  <ul>
+    <li *ngFor="let request of MOD_REQUESTS">
+      <a href="{{ request.link }}" target="_blank" rel="noopener noreferrer">{{ request.user }}</a>
+    </li>
+  </ul>
+
+  Unfortunately, I do not have much experience with these heavy overhaul mods, so I need your <strong>help</strong>.
+  <br />
+  The framework has been set up, all that is needed is more info!
+  <hr />
+
+  <p>Here are some different ways how you can contribute:</p>
+  <ul>
+    <li>
+      Submit a
+      <a href="https://github.com/deniszholob/factorio-cheat-sheet" target="_blank" rel="noopener noreferrer">pull request on github</a>
+    </li>
+    <li>
+      Create an
+      <a href="https://github.com/deniszholob/factorio-cheat-sheet/issues" target="_blank" rel="noopener noreferrer">"issue" on github</a>
+      to tell me what you want to see added!
+    </li>
+    <li>Contact me on <a href="https://discord.gg/PkyzXzz" target="_blank" rel="noopener noreferrer">Discord</a></li>
+    <li>Contact me on <a href="https://www.reddit.com/user/DDDGamer" target="_blank" rel="noopener noreferrer">Reddit</a></li>
+  </ul>
+</app-cheat-sheet-template>

--- a/src/app/cheat-sheets/game-mods/game-mods.component.spec.ts
+++ b/src/app/cheat-sheets/game-mods/game-mods.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { GameModsComponent } from './game-mods.component';
+import { GameModsModule } from './game-mods.module';
+
+describe('GameModsComponent', () => {
+  let component: GameModsComponent;
+  let fixture: ComponentFixture<GameModsComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [GameModsModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GameModsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/cheat-sheets/game-mods/game-mods.component.stories.ts
+++ b/src/app/cheat-sheets/game-mods/game-mods.component.stories.ts
@@ -1,0 +1,30 @@
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
+import { StorybookCsModule } from 'app/shared/storybook-cs.module';
+
+import { GameModsComponent } from './game-mods.component';
+import { GameModsModule } from './game-mods.module';
+
+type ComponentWithCustomControls = GameModsComponent;
+
+const meta: Meta<ComponentWithCustomControls> = {
+  title: 'Cheat Sheets/Game Mods',
+  component: GameModsComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [GameModsModule, StorybookCsModule],
+    }),
+  ],
+  parameters: {
+    docs: { description: { component: `GameMods` } },
+  },
+  argTypes: {},
+  args: {},
+};
+export default meta;
+
+const Template: Story<ComponentWithCustomControls> = (
+  args: ComponentWithCustomControls
+) => ({ props: args });
+
+export const GameMods = Template.bind({});
+GameMods.args = {};

--- a/src/app/cheat-sheets/game-mods/game-mods.component.ts
+++ b/src/app/cheat-sheets/game-mods/game-mods.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { MOD_REQUESTS, UserRequest } from './game-mods.data';
+
+@Component({
+  selector: 'app-game-mods',
+  templateUrl: './game-mods.component.html',
+})
+export class GameModsComponent {
+  public readonly iconId: string = 'Iron_gear_wheel';
+  public readonly title: string = 'Factorio Mods';
+  public readonly MOD_REQUESTS: UserRequest[] = MOD_REQUESTS;
+}

--- a/src/app/cheat-sheets/game-mods/game-mods.data.ts
+++ b/src/app/cheat-sheets/game-mods/game-mods.data.ts
@@ -1,0 +1,23 @@
+export type UserRequest = {
+  user: string;
+  link: string;
+};
+
+export const MOD_REQUESTS: UserRequest[] = [
+  {
+    user: 'Krastorio? @noerremark',
+    link: 'https://github.com/deniszholob/factorio-cheat-sheet/issues/235',
+  },
+  {
+    user: 'Krastorio2? @llsds',
+    link: 'https://www.reddit.com/r/factorio/comments/fwurwy/krastorio_2_cheat_sheet/',
+  },
+  {
+    user: 'Space Exploration? @jim_andr',
+    link: 'https://www.reddit.com/r/factorio/comments/zun4wh/comment/j1node6/?utm_source=share&utm_medium=web2x&context=3',
+  },
+  {
+    user: 'Bobs? @No-Stress9756',
+    link: 'https://www.reddit.com/r/factorio/comments/q2rtzl/bobs_mods_cheat_sheet/',
+  },
+];

--- a/src/app/cheat-sheets/game-mods/game-mods.module.spec.ts
+++ b/src/app/cheat-sheets/game-mods/game-mods.module.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GameModsModule } from './game-mods.module';
+
+describe('GameModsModule', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GameModsModule],
+    });
+  });
+
+  it('initializes', () => {
+    const module: GameModsModule = TestBed.inject(GameModsModule);
+    expect(module).toBeTruthy();
+  });
+});

--- a/src/app/cheat-sheets/game-mods/game-mods.module.ts
+++ b/src/app/cheat-sheets/game-mods/game-mods.module.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { CheatSheetTemplateModule } from 'app/shared/cheat-sheet-template/cheat-sheet-template.module';
+import { ROUTES_GAME_MODS } from './game-mods.routes';
+
+import { GameModsComponent } from './game-mods.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule.forChild(ROUTES_GAME_MODS),
+    CheatSheetTemplateModule,
+  ],
+  declarations: [GameModsComponent],
+  exports: [GameModsComponent, RouterModule],
+})
+export class GameModsModule {}

--- a/src/app/cheat-sheets/game-mods/game-mods.routes.ts
+++ b/src/app/cheat-sheets/game-mods/game-mods.routes.ts
@@ -1,0 +1,15 @@
+import { Routes } from '@angular/router';
+import { GameModsComponent } from './game-mods.component';
+
+export const ROOT_GAME_MODS = 'mods';
+export const ROUTES_GAME_MODS: Routes = [
+  {
+    path: ROOT_GAME_MODS,
+    component: GameModsComponent,
+  },
+  {
+    path: 'mod',
+    redirectTo: ROOT_GAME_MODS,
+    pathMatch: 'full',
+  },
+];

--- a/src/app/layout/main/main.component.html
+++ b/src/app/layout/main/main.component.html
@@ -2,9 +2,19 @@
   <div class="cheat-sheet-pages-title d-none-print">
     <div class="d-flex justify-content-between">
       <h2 class="d-inline-block" id="cheat-sheets">Cheat Sheets</h2>
+
+      <div class="input-group fixed-width width-auto m-0">
+        <span class="input-group-addon">Category</span>
+        <select class="form-select" [(ngModel)]="categorySelection" (ngModelChange)="updateCategory()" type="number">
+          <option *ngFor="let category of CHEAT_SHEET_CATEGORIES | keyvalue" [ngValue]="category.key">
+            {{ category.value }}
+          </option>
+        </select>
+      </div>
     </div>
+
     <hr />
   </div>
 
-  <app-game-base></app-game-base>
+  <router-outlet></router-outlet>
 </div>

--- a/src/app/layout/main/main.component.ts
+++ b/src/app/layout/main/main.component.ts
@@ -1,8 +1,38 @@
 // Angular Imports
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  CheatSheetCategory,
+  CHEAT_SHEET_CATEGORIES,
+} from 'app/cheat-sheets/cheat-sheets.module';
+import { Subject, takeUntil } from 'rxjs';
+import { navMatchFilter } from '../util';
 
 @Component({
   selector: 'app-main',
   templateUrl: './main.component.html',
 })
-export class MainComponent {}
+export class MainComponent implements OnDestroy {
+  private readonly clearSub$ = new Subject<void>();
+  public readonly CHEAT_SHEET_CATEGORIES = CHEAT_SHEET_CATEGORIES;
+  public categorySelection: CheatSheetCategory = 'base';
+
+  constructor(private router: Router) {
+    navMatchFilter(this.router)
+      .pipe(takeUntil(this.clearSub$))
+      .subscribe((key: CheatSheetCategory): void => {
+        this.categorySelection = key;
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.clearSub$.next();
+    this.clearSub$.complete();
+  }
+
+  public updateCategory(): void {
+    this.router.navigate([this.categorySelection.toLowerCase()], {
+      fragment: 'cheat-sheets', // No need to go to the top of the page, all the content is below
+    });
+  }
+}

--- a/src/app/layout/main/main.module.ts
+++ b/src/app/layout/main/main.module.ts
@@ -2,11 +2,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { GameBaseModule } from 'app/cheat-sheets/game-base/game-base.module';
+import { CheatSheetsModule } from 'app/cheat-sheets/cheat-sheets.module';
 import { MainComponent } from './main.component';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, RouterModule, GameBaseModule],
+  imports: [CommonModule, FormsModule, RouterModule, CheatSheetsModule],
   declarations: [MainComponent],
   exports: [MainComponent, RouterModule],
 })

--- a/src/app/layout/nav/nav.component.html
+++ b/src/app/layout/nav/nav.component.html
@@ -11,10 +11,8 @@
     </div>
   </div>
   <div class="nav-contents">
-    <a (click)="closeNav()" href="#Top">Top</a>
-    <a *ngFor="let sheet of sheetIds" (click)="clickedLink(sheet)" href="#{{ sheet }}">{{ sheetName(sheet) }}</a>
-    <!-- <a *ngFor="let sheet of sheetIds" [routerLink]="['./']" [fragment]="sheet" (click)="clickedLink(sheet)">{{ sheetName(sheet) }}</a> -->
-    <!-- <a (click)="closeNav()" href="#Annex">Annex</a> -->
+    <a [routerLink]="[]" [fragment]="'Top'" (click)="closeNav()">Top</a>
+    <a *ngFor="let sheet of sheetIds" [routerLink]="[]" [fragment]="sheet" (click)="clickedLink(sheet)">{{ sheetName(sheet) }}</a>
   </div>
 
   <!-- Use any element to open the side-nav -->

--- a/src/app/layout/nav/nav.data.ts
+++ b/src/app/layout/nav/nav.data.ts
@@ -1,4 +1,6 @@
-export const NAV_DATA: string[] = [
+import { CheatSheetCategory } from 'app/cheat-sheets/cheat-sheets.module';
+
+export const NAV_BASE: string[] = [
   'common-ratios',
   'belts',
   'balancers',
@@ -19,3 +21,9 @@ export const NAV_DATA: string[] = [
   'tips',
   'links',
 ];
+export const NAV_MODS: string[] = ['factorio-mods'];
+
+export const NAV_ANCHOR_TAGS: Record<CheatSheetCategory, string[]> = {
+  base: NAV_BASE,
+  mods: NAV_MODS,
+};

--- a/src/app/layout/nav/nav.module.ts
+++ b/src/app/layout/nav/nav.module.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 import { NavComponent } from './nav.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   declarations: [NavComponent],
   exports: [NavComponent],
 })

--- a/src/app/layout/overview/overview.component.html
+++ b/src/app/layout/overview/overview.component.html
@@ -18,7 +18,7 @@
     on
     <a href="https://github.com/deniszholob/factorio-cheat-sheet/" target="_blank" rel="noopener">GitHub</a>, as well as the community who
     made the
-    <a href="#Old_Cheat_Sheets">previous cheat sheets</a>
+    <a href="https://github.com/deniszholob/factorio-cheat-sheet/releases">previous cheat sheets</a>
     and other resources; such as the
     <a href="https://wiki.factorio.com/" target="_blank" rel="noopener">Wiki</a>,
     <a href="https://www.reddit.com/r/factorio" target="_blank" rel="noopener">Reddit</a>, and
@@ -35,9 +35,9 @@
         <li>
           <strong>New Players</strong>
           make sure to check the
-          <a href="#links">Links</a>
+          <a [routerLink]="[]" fragment="links">Links</a>
           and
-          <a href="#tips">Tips</a>
+          <a [routerLink]="[]" fragment="tips">Tips</a>
           Sections
         </li>
         <li>
@@ -50,7 +50,7 @@
         <li>Any section that deals with ratios assumes no modules are used, and consistent assembly machines.</li>
         <li>
           The ratio sections are a starting point only, for advanced ratios use a
-          <a href="#CommunityLinks">calculator</a>.
+          <a [routerLink]="[]" fragment="CommunityLinks">calculator</a>.
         </li>
         <li>Any of the sections can be collapsed/expanded by toggling the top right corner (-/+).</li>
         <li>

--- a/src/app/layout/overview/overview.module.ts
+++ b/src/app/layout/overview/overview.module.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 import { OverviewComponent } from './overview.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   declarations: [OverviewComponent],
   exports: [OverviewComponent],
 })

--- a/src/app/layout/util.ts
+++ b/src/app/layout/util.ts
@@ -1,0 +1,24 @@
+import { Event, NavigationEnd, Router } from '@angular/router';
+import { CheatSheetCategory } from 'app/cheat-sheets/cheat-sheets.module';
+import { filter, map } from 'rxjs';
+import { NAV_ANCHOR_TAGS } from './nav/nav.data';
+
+/** Checks the navigation url and return the extracted base part as its what is used for the cheat sheet categories*/
+export function navMatchFilter(router: Router) {
+  return router.events.pipe(
+    filter(
+      (event: Event): event is NavigationEnd => event instanceof NavigationEnd
+    ),
+    map((event: NavigationEnd) => {
+      const match = RegExp(/^\/([^#]*)/).exec(event.urlAfterRedirects);
+      if (match && match[1]) {
+        return match[1];
+      }
+      return;
+    }),
+    filter(
+      (matchedString?: string): matchedString is CheatSheetCategory =>
+        !!matchedString && matchedString in NAV_ANCHOR_TAGS
+    )
+  );
+}

--- a/src/app/shared/cheat-sheet-template/cheat-sheet-template.component.html
+++ b/src/app/shared/cheat-sheet-template/cheat-sheet-template.component.html
@@ -1,6 +1,6 @@
 <div class="card cheat-sheet" id="{{ id }}">
   <div class="card-header" (click)="toggleCollapse()">
-    <a href="#{{ id }}">
+    <a [routerLink]="[]" [fragment]="id">
       <app-factorio-icon [icon]="factorioIcon"></app-factorio-icon>
       <h3 class="card-title">
         {{ title }}

--- a/src/app/shared/cheat-sheet-template/cheat-sheet-template.component.stories.ts
+++ b/src/app/shared/cheat-sheet-template/cheat-sheet-template.component.stories.ts
@@ -1,4 +1,5 @@
 import { CommonModule } from '@angular/common';
+import { RouterTestingModule } from '@angular/router/testing';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { SheetCollapseToggleService } from 'app/services';
 import { FactorioIconIds } from '../factorio-icon/factorio-icon.model';
@@ -19,7 +20,7 @@ const meta: Meta<ComponentWithCustomControls> = {
   component: CheatSheetTemplateComponent,
   decorators: [
     moduleMetadata({
-      imports: [CommonModule, CheatSheetTemplateModule],
+      imports: [CommonModule, CheatSheetTemplateModule, RouterTestingModule],
       // declarations: [],
       providers: [SheetCollapseToggleService],
     }),

--- a/src/app/shared/cheat-sheet-template/cheat-sheet-template.module.ts
+++ b/src/app/shared/cheat-sheet-template/cheat-sheet-template.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { DataService } from 'app/services';
 import { AdSenseModule } from '../ad-sense/ad-sense.module';
@@ -7,7 +8,13 @@ import { FactorioIconModule } from '../factorio-icon/factorio-icon.module';
 import { CheatSheetTemplateComponent } from './cheat-sheet-template.component';
 
 @NgModule({
-  imports: [CommonModule, FactorioIconModule, AdSenseModule, NgbCollapseModule],
+  imports: [
+    CommonModule,
+    FactorioIconModule,
+    AdSenseModule,
+    NgbCollapseModule,
+    RouterModule,
+  ],
   declarations: [CheatSheetTemplateComponent],
   exports: [CheatSheetTemplateComponent],
   providers: [DataService],

--- a/src/app/shared/cheat-sheet/cheat-sheet.component.html
+++ b/src/app/shared/cheat-sheet/cheat-sheet.component.html
@@ -1,6 +1,6 @@
 <div class="card cheat-sheet" id="{{ cheatSheet?.id }}">
   <div class="card-header" (click)="cheatSheet?.toggleCollapse()">
-    <a href="#{{ cheatSheet?.id }}">
+    <a [routerLink]="[]" fragment="{{ cheatSheet?.id }}">
       <app-factorio-icon [icon]="cheatSheet?.icon"></app-factorio-icon>
       <h3 class="card-title">
         {{ cheatSheet?.title }}

--- a/src/app/shared/cheat-sheet/cheat-sheet.component.stories.ts
+++ b/src/app/shared/cheat-sheet/cheat-sheet.component.stories.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from '@angular/common';
+import { RouterTestingModule } from '@angular/router/testing';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { DataService, SheetCollapseToggleService } from 'app/services';
-import { AdSenseComponent } from '../ad-sense/ad-sense.component';
 import { AdSenseModule } from '../ad-sense/ad-sense.module';
 import { FactorioIconComponent } from '../factorio-icon/factorio-icon.component';
 import {
@@ -23,7 +23,12 @@ const meta: Meta<ComponentWithCustomControls> = {
   component: CheatSheetComponent,
   decorators: [
     moduleMetadata({
-      imports: [CommonModule, AdSenseModule, NgbCollapseModule],
+      imports: [
+        CommonModule,
+        AdSenseModule,
+        NgbCollapseModule,
+        RouterTestingModule,
+      ],
       declarations: [FactorioIconComponent],
       providers: [SheetCollapseToggleService],
     }),

--- a/src/app/shared/cheat-sheet/cheat-sheet.module.ts
+++ b/src/app/shared/cheat-sheet/cheat-sheet.module.ts
@@ -1,11 +1,18 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { CheatSheetComponent, FactorioIconModule } from 'app/shared';
 import { AdSenseModule } from '../ad-sense/ad-sense.module';
 
 @NgModule({
-  imports: [CommonModule, FactorioIconModule, AdSenseModule, NgbCollapseModule],
+  imports: [
+    CommonModule,
+    FactorioIconModule,
+    AdSenseModule,
+    NgbCollapseModule,
+    RouterModule,
+  ],
   declarations: [CheatSheetComponent],
   exports: [CheatSheetComponent],
 })

--- a/src/app/shared/storybook-cs.module.ts
+++ b/src/app/shared/storybook-cs.module.ts
@@ -1,9 +1,10 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgModule } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
 import { DataService, SheetCollapseToggleService } from 'app/services';
 
 @NgModule({
-  imports: [HttpClientTestingModule],
+  imports: [HttpClientTestingModule, RouterTestingModule],
   providers: [DataService, SheetCollapseToggleService],
 })
 export class StorybookCsModule {}


### PR DESCRIPTION
Add support for more cheat sheets using categories #235

* Overhaul navigation to use angular native anchor routing
* Add category selector next to Cheat Sheets title
* Nav dynamically updates based on category
* Add base game routes (redirect "/" to "/base")
* Add mods category module and routes

Change anchor tags to be relative to url

* Change href="#" to [routerLink]="[]" fragment="" since otherwise anchor links are not relative to current url but to base url (instead of /base#top its /#top)