### PR TITLE
Swap Stone and Iron_plate material-processing inputs

### DIFF
--- a/src/app/cheat-sheets/game-base/material-processing/material-processing.data.ts
+++ b/src/app/cheat-sheets/game-base/material-processing/material-processing.data.ts
@@ -24,28 +24,28 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
     beltEmpty: [
       {
         processor: ['Stone_furnace'],
-        material: ['Copper_ore', 'Iron_ore', 'Iron_plate'],
+        material: ['Copper_ore', 'Iron_ore', 'Stone'],
         beltYellow: 48,
         beltRed: 96,
         beltBlue: 144,
       },
       {
         processor: ['Steel_furnace', 'Electric_furnace'],
-        material: ['Copper_ore', 'Iron_ore', 'Iron_plate'],
+        material: ['Copper_ore', 'Iron_ore', 'Stone'],
         beltYellow: 24,
         beltRed: 48,
         beltBlue: 72,
       },
       {
         processor: ['Stone_furnace'],
-        material: ['Stone'],
+        material: ['Iron_plate'],
         beltYellow: 24,
         beltRed: 48,
         beltBlue: 72,
       },
       {
         processor: ['Steel_furnace', 'Electric_furnace'],
-        material: ['Stone'],
+        material: ['Iron_plate'],
         beltYellow: 12,
         beltRed: 24,
         beltBlue: 36,


### PR DESCRIPTION
Hi there,

I think I noticed a typo where stone and Iron plate are swapped in the left-hand table of the Material Processing section.

According to other sources (and the words below the tables), stone takes the same amount of smelting time as copper and iron ore, so should take the same number of machines to empty an input belt. (...Right?)

I'm guessing this is the change needed to fix it but I haven't built the app to test, so lmk if another change is needed. (Or feel free to reject if I'm just totally wrong here. :)

Thanks for maintaining this awesome site!