### PR TITLE
Basic power entry incorrectly states that a boiler consumes 1.8 MJ of fuel

### DIFF
--- a/src/app/cheat-sheets/game-base/basic-power/basic-power.component.html
+++ b/src/app/cheat-sheets/game-base/basic-power/basic-power.component.html
@@ -65,7 +65,7 @@
     </li>
     <li>
       A steam boiler consumes
-      {{ sheetData?.steam_boiler_energy }}
+      {{ sheetData?.steam_boiler_power }}
       of fuel.
     </li>
     <li>

--- a/src/app/cheat-sheets/game-base/basic-power/basic-power.component.html
+++ b/src/app/cheat-sheets/game-base/basic-power/basic-power.component.html
@@ -65,8 +65,8 @@
     </li>
     <li>
       A steam boiler consumes
-      {{ sheetData?.steam_boiler_power }}
-      of fuel.
+      {{ sheetData?.steam_boiler_energy }}
+      of fuel per second.
     </li>
     <li>
       A

--- a/src/app/cheat-sheets/game-base/basic-power/basic-power.data.ts
+++ b/src/app/cheat-sheets/game-base/basic-power/basic-power.data.ts
@@ -40,7 +40,6 @@ export const BASIC_POWER_DATA: RawData<BasicPowerData> = {
     offshore_pump_water: 1200,
     steam_boiler_fluid: 60,
     steam_boiler_energy: '1.8MJ',
-    steam_boiler_power: '1.8MW',
     steam_engine_fluid: 30,
     steam_engine_power: '0.9MW',
     solar_energy_max: 60,

--- a/src/app/cheat-sheets/game-base/basic-power/basic-power.data.ts
+++ b/src/app/cheat-sheets/game-base/basic-power/basic-power.data.ts
@@ -40,6 +40,7 @@ export const BASIC_POWER_DATA: RawData<BasicPowerData> = {
     offshore_pump_water: 1200,
     steam_boiler_fluid: 60,
     steam_boiler_energy: '1.8MJ',
+    steam_boiler_power: '1.8MW',
     steam_engine_fluid: 30,
     steam_engine_power: '0.9MW',
     solar_energy_max: 60,


### PR DESCRIPTION
It should say "A steam boiler consumes 1.8MJ of fuel per second" or 1.8MW.