### PR TITLE
Remove Deprecated html-snippet

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
 
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "abusaidm.html-snippets",
     "aessoft.aessoft-class-autocomplete",
     "angular.ng-template",
     "davidbabel.vscode-simpler-icons",


### PR DESCRIPTION
"Disabling this extension as its functionality has been absorbed by VS Code main html extension."