### PR TITLE
chore: disable Angular analytics

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -123,6 +123,7 @@
     }
   },
   "cli": {
-    "schematicCollections": ["@angular-eslint/schematics"]
+    "schematicCollections": ["@angular-eslint/schematics"],
+    "analytics": false
   }
 }


### PR DESCRIPTION
## Changes:

- Disable Angular asking for analytics

## Context:

When you run `npm run start` it runs the `ng serve --port 9009` command. On a fresh installation, Angular then asks for permission to gather some analytics. 

I automated setting up a developer environment. You'll get a PR from me soon:

- #407

For the automated setup to work properly, Angular should _not_ ask for input during the Codespace build steps.

I told Angular to stop asking for permission, by setting `analytics=false` in the `angular.json` config file.

### Docs

See the [Angular CLI configuration options](https://angular.dev/reference/configs/workspace-config#angular-cli-configuration-options) table, search for the `analytics` keyword.