### PR TITLE
chore: create devcontainer for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+  "name": "Node.js",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "npm run i && npm run start"
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}


### PR DESCRIPTION
## Changes:

- Create `.devcontainer` file with GitHub Codespaces setup
- Use Node 22 as basis for the container image

## Context:

With my changes you can:

- Create a development enviroment by clicking on the green `<> Code` button on any branch of your repository (this also works on forks that have pulled in this change)
- You can use the browser to work on your change, and see the preview of the live site
- You do not need to worry about installing the right dependencies

You will need to update the `"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",` part from time to time. GitHub added a Dependabot config during the setup steps for the Node.js container.

I recommend using a bot to update the container file regularly. It's easy to forget. 😄 

### Docs

- [GitHub Docs, GitHub Codespaces overview](https://docs.github.com/en/codespaces/overview)
- [GitHub Docs, Working in a Codespace in the browser](https://docs.github.com/en/codespaces/developing-in-a-codespace/developing-in-a-codespace#working-in-a-codespace-in-the-browser)