### PR TITLE
chore: cache Prettier runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "watch": "ng build --watch --configuration development",
     "test": "echo 'No tests'",
     "lint": "ng lint",
-    "format": "prettier --write --ignore-unknown  .",
-    "format:check": "prettier --check  --ignore-unknown .",
+    "format": "prettier --cache --write --ignore-unknown  .",
+    "format:check": "prettier --cache --check  --ignore-unknown .",
     "prepare": "husky install",
     "pre-commit": "npx lint-staged",
     "docs:json": "compodoc -p ./tsconfig.json -e json -d .",
@@ -36,7 +36,7 @@
       "eslint --fix"
     ],
     "**/*": [
-      "prettier --write --ignore-unknown"
+      "prettier --cache --write --ignore-unknown"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Changes:

- Cache the result from earlier Prettier runs, to speed up running Prettier at a later time

## Context:

You can cache the result of Prettier runs locally. That way:

- The first run is a bit slower (due to needing to write a cache file)
- But later Prettier runs will only check files that change, so it's really fast

### Docs

Read the [Prettier docs for the CLI, `--cache` config option](https://prettier.io/docs/en/cli.html#--cache) to learn the full details.