### PR TITLE
add turbo belts to material processing

### DIFF
--- a/src/app/cheat-sheets/game-base/material-processing/material-processing.component.html
+++ b/src/app/cheat-sheets/game-base/material-processing/material-processing.component.html
@@ -9,7 +9,7 @@
         <thead class="text-center">
           <tr>
             <th colspan="2">Machines needed<a [routerLink]="[]" fragment="note_building_processing">^</a> to</th>
-            <th colspan="3">Empty input belt</th>
+            <th colspan="4">Empty input belt</th>
           </tr>
           <tr>
             <th>With</th>
@@ -22,6 +22,9 @@
             </th>
             <th>
               <app-factorio-icon [icon]="dataService.getFactorioIcon('Express_transport_belt')"></app-factorio-icon>
+            </th>
+            <th>
+              <app-factorio-icon [icon]="dataService.getFactorioIcon('Turbo_transport_belt')"></app-factorio-icon>
             </th>
           </tr>
         </thead>
@@ -36,6 +39,7 @@
             <td class="bg-input" title="Machines">{{ item?.beltYellow }}</td>
             <td class="bg-input" title="Machines">{{ item?.beltRed }}</td>
             <td class="bg-input" title="Machines">{{ item?.beltBlue }}</td>
+            <td class="bg-input" title="Machines">{{ item?.beltGreen }}</td>
           </tr>
         </tbody>
       </table>
@@ -46,7 +50,7 @@
         <thead class="text-center">
           <tr>
             <th colspan="2">Machines needed<a [routerLink]="[]" fragment="note_building_processing">^</a> to</th>
-            <th colspan="3">Fill output belt</th>
+            <th colspan="4">Fill output belt</th>
           </tr>
           <tr>
             <th>With</th>
@@ -59,6 +63,9 @@
             </th>
             <th>
               <app-factorio-icon [icon]="dataService.getFactorioIcon('Express_transport_belt')"></app-factorio-icon>
+            </th>
+            <th>
+              <app-factorio-icon [icon]="dataService.getFactorioIcon('Turbo_transport_belt')"></app-factorio-icon>
             </th>
           </tr>
         </thead>
@@ -73,6 +80,7 @@
             <td class="bg-output" title="Machines">{{ item?.beltYellow }}</td>
             <td class="bg-output" title="Machines">{{ item?.beltRed }}</td>
             <td class="bg-output" title="Machines">{{ item?.beltBlue }}</td>
+            <td class="bg-output" title="Machines">{{ item?.beltGreen }}</td>
           </tr>
         </tbody>
       </table>

--- a/src/app/cheat-sheets/game-base/material-processing/material-processing.component.ts
+++ b/src/app/cheat-sheets/game-base/material-processing/material-processing.component.ts
@@ -6,15 +6,15 @@ import { DataService } from 'app/services/data.service';
 
 // Models
 import { Data } from 'app/models/Data.model';
-import { CheatSheet } from 'app/shared/cheat-sheet/cheat-sheet.model';
 import { MaterialProcessingData } from 'app/models/MaterialProcessingData.model';
+import { CheatSheet } from 'app/shared/cheat-sheet/cheat-sheet.model';
 
 // Constants
-import { MATERIAL_PROCESSING_DATA } from './material-processing.data';
 import { FactorioIconData } from 'app/shared/factorio-icon/factorio-icon.model';
-import { BELT_DATA, BeltData } from '../mining/belt.data';
-import { FurnaceData, FURNACES_DATA } from './furnaces.data';
 import { BURNABLES_DATA } from '../basic-power/burnables.data';
+import { BeltData, BELT_DATA } from '../mining/belt.data';
+import { FurnaceData, FURNACES_DATA } from './furnaces.data';
+import { MATERIAL_PROCESSING_DATA } from './material-processing.data';
 
 interface CoalFurnaceTableColumn {
   text?: string;
@@ -83,14 +83,14 @@ export class MaterialProcessingComponent implements OnInit {
   ngOnInit() {
     this.dataService
       .getLocalCheatSheetData<MaterialProcessingData>(MATERIAL_PROCESSING_DATA)
-      .subscribe(
-        (result: Data<MaterialProcessingData>) => {
+      .subscribe({
+        next: (result: Data<MaterialProcessingData>) => {
           this.cheatSheet = result.cheatSheet;
           this.sheetData = result.data;
         },
-        (error) => {
+        error: (error) => {
           console.log(error);
-        }
-      );
+        },
+      });
   }
 }

--- a/src/app/cheat-sheets/game-base/material-processing/material-processing.data.ts
+++ b/src/app/cheat-sheets/game-base/material-processing/material-processing.data.ts
@@ -14,6 +14,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 48,
         beltRed: 96,
         beltBlue: 144,
+        beltGreen: 192,
       },
       {
         processor: ['Steel_furnace', 'Electric_furnace'],
@@ -21,6 +22,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 24,
         beltRed: 48,
         beltBlue: 72,
+        beltGreen: 96,
       },
       {
         processor: ['Stone_furnace'],
@@ -28,6 +30,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 24,
         beltRed: 48,
         beltBlue: 72,
+        beltGreen: 96,
       },
       {
         processor: ['Steel_furnace', 'Electric_furnace'],
@@ -35,6 +38,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 12,
         beltRed: 24,
         beltBlue: 36,
+        beltGreen: 48,
       },
       {
         processor: ['Centrifuge'],
@@ -42,6 +46,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 18,
         beltRed: 36,
         beltBlue: 54,
+        beltGreen: 72,
       },
     ],
     beltFill: [
@@ -51,6 +56,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 48,
         beltRed: 96,
         beltBlue: 144,
+        beltGreen: 192,
       },
       {
         processor: ['Steel_furnace', 'Electric_furnace'],
@@ -58,6 +64,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 24,
         beltRed: 48,
         beltBlue: 72,
+        beltGreen: 96,
       },
       {
         processor: ['Stone_furnace'],
@@ -65,6 +72,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 240,
         beltRed: 480,
         beltBlue: 720,
+        beltGreen: 960,
       },
       {
         processor: ['Steel_furnace', 'Electric_furnace'],
@@ -72,6 +80,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 120,
         beltRed: 240,
         beltBlue: 360,
+        beltGreen: 480,
       },
       {
         processor: ['Centrifuge'],
@@ -79,6 +88,7 @@ export const MATERIAL_PROCESSING_DATA: RawData<MaterialProcessingData> = {
         beltYellow: 180,
         beltRed: 360,
         beltBlue: 540,
+        beltGreen: 720,
       },
     ],
   },

--- a/src/app/models/MaterialProcessingData.model.ts
+++ b/src/app/models/MaterialProcessingData.model.ts
@@ -9,4 +9,5 @@ export interface Belt {
   beltYellow: number;
   beltRed: number;
   beltBlue: number;
+  beltGreen: number;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8e0337bd-fbb4-45d3-ab98-0d589de984ae)
I added turbo belts to the material processing area. I've not necessarily used them for this (since you get foundries etc.), but I found that I'd like to see the ratio.

If someone could also please double-check the amounts :)

I also resolved a small deprecation.