### PR TITLE
Bump upload and download artifacts actions to v4

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -49,7 +49,7 @@ jobs:
       # https://docs.github.com/en/actions/learn-github-actions/essential-features-of-github-actions#sharing-data-between-jobs
       - name: Archive web demo build
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: public
           path: public # Directory to push to GitHub Pages
@@ -64,7 +64,7 @@ jobs:
   #       uses: actions/checkout@v3
 
   #     - name: Download build
-  #       uses: actions/download-artifact@v3
+  #       uses: actions/download-artifact@v4
   #       with:
   #         name: public
   #         path: public

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       # https://docs.github.com/en/actions/learn-github-actions/essential-features-of-github-actions#sharing-data-between-jobs
       - name: Archive web demo build
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: public
           path: public # Directory to push to GitHub Pages
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: public
           path: public
@@ -85,7 +85,7 @@ jobs:
   #       uses: actions/checkout@v3
 
   #     - name: Download build
-  #       uses: actions/download-artifact@v3
+  #       uses: actions/download-artifact@v4
   #       with:
   #         name: public
   #         path: public


### PR DESCRIPTION
## Changes:

- Update `actions/upload-artifact@v3` to `v4`
- Update `actions/download-artifact@v3` to `v4` 

## Context:

My PR to update the text in the overview component is automatically failing, because we're using old versions of these actions.

I only bumped the number from v3 to v4. I don't yet know if this is enough to get things working again. Testing GitHub Actions locally is nearly impossible...

## References:

- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
- https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/#compatibility