### PR TITLE
Run Prettier and Angular linters during pre-commit step

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,6 @@ export NVM_DIR="$HOME/.nvm"
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run pre-commit
+
+npm run format
+npm run lint


### PR DESCRIPTION
## Changes:

- Run Prettier and Angular linters during pre-commit step with Husky

## Context:

This should run the Prettier and Angular linters during the pre-commit step.

Alternative option: include the Prettier and Angular linter run commands in the `pre-commit` script in the `package.json` file.

Helps with issue:

- #427