### PR TITLE
Rewrite shortcuts in tips section

### DIFF
--- a/src/app/cheat-sheets/game-base/tips/tips.component.html
+++ b/src/app/cheat-sheets/game-base/tips/tips.component.html
@@ -1,75 +1,76 @@
 <app-cheat-sheet [cheatSheet]="cheatSheet">
   <h4 id="tips-shortcuts">
     <a href="https://wiki.factorio.com/Tutorial:Keyboard_shortcuts" target="_blank" rel="noopener"> Shortcuts </a>
-    <small class="text-muted">(Most Used)</small>
+    <small class="text-muted">(Most used)</small>
   </h4>
   <ul>
     <li>
       <kbd>Alt</kbd>
-      - reveal detailed information on entities, you can also use the
-      <a href="https://wiki.factorio.com/Shortcut_bar" target="_blank" rel="noopener">shortcut bar (click on the ALT button)</a>.
+      Show detailed information on entities. Or click the ALT button in the
+      <a href="https://wiki.factorio.com/Shortcut_bar" target="_blank" rel="noopener">shortcut bar</a>.
     </li>
     <li>
       <kbd>MMB</kbd>
-      - clear an item in the
-      <a href="https://wiki.factorio.com/Quickbar" target="_blank" rel="noopener">quick bar</a>, and can set filters in cargo wagons and
-      your inventory. (<kbd>CMD+RMB</kbd>
-      on macOS)
+      Clear the item in the <a href="https://wiki.factorio.com/Quickbar" target="_blank" rel="noopener">quick bar</a>. Or set filters in
+      cargo wagons and your inventory. (<kbd>CMD+RMB</kbd> on macOS)
     </li>
     <li>
       <kbd>R</kbd>
-      - rotate entities, even when already placed,
-      <kbd>Shift+R</kbd>
-      for the opposite.
+      Rotate ghosts (or built entities) clockwise.
     </li>
     <li>
-      <kbd>CTRL-LMB</kbd>
-      - Put/Take All Items,
-      <kbd>CTRL-RMB</kbd>
-      - Put/Take Half Items.
+      <kbd>Shift + R</kbd>
+      Rotate ghosts (or built entities) counterclockwise.
+    </li>
+    <li>
+      <kbd>CTRL + LMB</kbd>
+      Put or take all items.
+    </li>
+    <li>
+      <kbd>CTRL + RMB</kbd>
+      Put or take a half stack of items.
     </li>
     <li>
       <kbd>Z</kbd>
-      Drop 1 Item (can do it directly into machines)
+      Drop 1 item over the cursor. You can feed one item into a Assembly machine or chest.
     </li>
     <li>
       <kbd>F</kbd>
-      Pick up items from ground
+      Pick up items from the ground or belt.
     </li>
     <li>
-      Hold
-      <kbd>Shift</kbd>
-      while building to place a ghost of the item (single entity blueprint).
+      Place a ghost of the item by holding <kbd>Shift</kbd>
+      while building.
     </li>
     <li>
-      <kbd>Shift+RMB</kbd>
-      will copy entity configurations,
-      <kbd>Shift+LMB</kbd>
-      will paste them.
+      <kbd>Shift + RMB</kbd>
+      Copy entity configuration.
+      <kbd>Shift + LMB</kbd>
+      Paste entity configuration.
       <ul>
-        <li>This works for: filter inserters, assemblers, requester chests, combinators, etc...</li>
-        <li>You can paste across multiple entities by dragging.</li>
+        <li>Copy/pasting the configuration works on inserters, assemblers, requester chests, combinators, etc.</li>
         <li>
-          You can copy from assemblers into requester chests (requests the required amount to craft 30 seconds worth of the item
-          production).
+          Set up requester chests by copy/pasting the assembler config to the requester chest. This requests enough items for 30 seconds of
+          production.
         </li>
-        <li>You can copy individual slots (inventory, cargo wagon).</li>
+        <li>Copy/paste the config to multiple entities by dragging the mouse.</li>
+        <li>Copy individual slots (inventory, cargo wagon).</li>
       </ul>
     </li>
     <li>
-      <kbd>Q</kbd>
-      while hovering over anything to quick-select it from your inventory.
+      Use <kbd>Q</kbd>
+      while hovering over anything to select it from your inventory.
       <ul>
         <li>
-          Press
+          Use
           <kbd>Q</kbd>
-          on ores to select miners.
+          while hovering over any ore to select the best miner in your inventory.
         </li>
       </ul>
     </li>
     <li>
-      <kbd>CTRL+C</kbd>, <kbd>CTRL+V</kbd>, <kbd>CTRL+X</kbd>, <kbd>CTRL+Z</kbd>, <kbd>CTRL+Y</kbd>
-      - copy, paste, cut, undo and redo your builds.
+      <kbd>CTRL + C</kbd>, <kbd>CTRL + V</kbd>, <kbd>CTRL + X</kbd>, <kbd>CTRL + Z</kbd>, <kbd>CTRL + Y</kbd>
+      Copy, paste, cut, undo and redo your builds.
       <small
         >(<kbd>CMD</kbd>
         vs
@@ -78,23 +79,21 @@
       >
     </li>
     <li>
-      <kbd>Numpad-</kbd>
-      /
-      <kbd>Numpad+</kbd>
-      - increase / decrease the size of any placed tile (such as landfill or concrete).
+      <kbd>Numpad -</kbd>
+      or
+      <kbd>Numpad +</kbd>
+      Increase or decrease the size of buildable tiles. For example: landfill, stone brick, concrete, artificial yumako soil, and
+      foundation.
     </li>
     <li>
-      <kbd>Shift+RMB</kbd>
-      - clear Blueprint or Deconstruction Planner Filters.
+      <kbd>Shift + RMB</kbd>
+      Clear Blueprint or Deconstruction planner filter.
     </li>
     <li>
-      <kbd>Shift+LMB</kbd>
-      - ping the ground/map.
+      <kbd>Shift + LMB</kbd>
+      Ping the ground and the map.
     </li>
-    <li>
-      <kbd>`</kbd>
-      (tilde key) - Open chat/command line.
-    </li>
+    <li><kbd>~</kbd> Open the chat/command line.</li>
   </ul>
 
   <h4 id="tips-cmd">

--- a/src/app/cheat-sheets/game-base/tips/tips.component.html
+++ b/src/app/cheat-sheets/game-base/tips/tips.component.html
@@ -39,8 +39,7 @@
       Pick up items from the ground or belt.
     </li>
     <li>
-      Place a ghost of the item by holding <kbd>Shift</kbd>
-      while building.
+      <kbd>Shift + LMB</kbd> Build a ghost of the item.
     </li>
     <li>
       <kbd>Shift + RMB</kbd>
@@ -64,7 +63,7 @@
         <li>
           Use
           <kbd>Q</kbd>
-          while hovering over any ore to select the best miner in your inventory.
+          on ores to select miners.
         </li>
       </ul>
     </li>
@@ -82,8 +81,7 @@
       <kbd>Numpad -</kbd>
       or
       <kbd>Numpad +</kbd>
-      Increase or decrease the size of buildable tiles. (Landfill, concrete etc...)
-      foundation.
+      Increase or decrease the size of buildable tiles, like landfill, concrete, etc.
     </li>
     <li>
       <kbd>Shift + RMB</kbd>

--- a/src/app/cheat-sheets/game-base/tips/tips.component.html
+++ b/src/app/cheat-sheets/game-base/tips/tips.component.html
@@ -38,9 +38,7 @@
       <kbd>F</kbd>
       Pick up items from the ground or belt.
     </li>
-    <li>
-      <kbd>Shift + LMB</kbd> Build a ghost of the item.
-    </li>
+    <li><kbd>Shift + LMB</kbd> Build a ghost of the item.</li>
     <li>
       <kbd>Shift + RMB</kbd>
       Copy entity configuration.

--- a/src/app/cheat-sheets/game-base/tips/tips.component.html
+++ b/src/app/cheat-sheets/game-base/tips/tips.component.html
@@ -82,7 +82,7 @@
       <kbd>Numpad -</kbd>
       or
       <kbd>Numpad +</kbd>
-      Increase or decrease the size of buildable tiles. For example: landfill, stone brick, concrete, artificial yumako soil, and
+      Increase or decrease the size of buildable tiles. (Landfill, concrete etc...)
       foundation.
     </li>
     <li>


### PR DESCRIPTION
## Changes:

- Rewrite the shortcuts in the tips section
- Use simple words and phrases
- Write short sentences
- End list items with a full stop
- Use correct symbol for the tilde character: ~
- Add whitespace in the keyboard command shortcuts
- Separate some items into two list items

## Context:

Improving the tips in the shortcut section. 😄

## Preview

![preview-rewrite-shortcuts-section](https://github.com/user-attachments/assets/09f305f8-ca4e-4e3f-813f-0716ea21026b)