### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/src/app/cheat-sheets/game-base/tips/tips.component.html
+++ b/src/app/cheat-sheets/game-base/tips/tips.component.html
@@ -10,6 +10,18 @@
       <a href="https://wiki.factorio.com/Shortcut_bar" target="_blank" rel="noopener">shortcut bar</a>.
     </li>
     <li>
+      <kbd>M</kbd>
+      Open or close the map view.
+    </li>
+    <li>
+      <kbd>O</kbd>
+      Open or close the train view.
+    </li>
+    <li>
+      <kbd>P</kbd>
+      Open or close the production view.
+    </li>
+    <li>
       <kbd>MMB</kbd>
       Clear the item in the <a href="https://wiki.factorio.com/Quickbar" target="_blank" rel="noopener">quick bar</a>. Or set filters in
       cargo wagons and your inventory. (<kbd>CMD+RMB</kbd> on macOS)


### PR DESCRIPTION
## Changes:

- Add keyboard shortcuts for these views:
  - M for the map
  - O for the trains
  - P for the production

I did _not_ add the tip about using Q to deselect items. I just hover over the next thing I want to select, and use Q then. 😉 

## Context:

Closes #419

## Preview:

![preview-add-shortcuts](https://github.com/user-attachments/assets/bc0f9cc0-f36c-4841-a441-d4e9fbb16d7e)
