### PR TITLE
Minor typo in modules-and-beacons.component.html

### DIFF
--- a/src/app/cheat-sheets/game-base/modules-and-beacons/modules-and-beacons.component.html
+++ b/src/app/cheat-sheets/game-base/modules-and-beacons/modules-and-beacons.component.html
@@ -69,7 +69,7 @@
             ></app-factorio-icon>
             Quality Modules
           </a>
-          increase the change to get higher quality items (SA only).
+          increase the chance to get higher quality items (SA only).
           <ul>
             <li>Speed modules counteract this effect so do no mix or use "speed beacons"</li>
             <li>Use quality machines to save on space esp useful on space platforms</li>


### PR DESCRIPTION
Fix a minor typo

```
increase the change to get higher quality items (SA only).
```
should be
```
increase the chance to get higher quality items (SA only).
```