### PR TITLE
Improve icon type code

### DIFF
--- a/src/app/cheat-sheets/game-base/train-colors/train-colors.component.html
+++ b/src/app/cheat-sheets/game-base/train-colors/train-colors.component.html
@@ -46,7 +46,7 @@
       <tr *ngFor="let item of displayedData">
         <td>
           <app-factorio-icon [icon]="dataService.getFactorioIcon(item.icon)"></app-factorio-icon>
-          {{ item.type ? item.type : (item.icon | replace) }}
+          {{ item.type ? item.type : (FACTORIO_ICONS_INFO[item.icon].display | replace) }}
         </td>
         <td>
           {{ item.rgb[0] }}, {{ item.rgb[1] }},

--- a/src/app/cheat-sheets/game-base/train-colors/train-colors.component.ts
+++ b/src/app/cheat-sheets/game-base/train-colors/train-colors.component.ts
@@ -6,6 +6,7 @@ import { TrainColor, TrainColorsData } from 'app/models/TrainColorsData.model';
 // Services
 import { DataService } from 'app/services/data.service';
 import { CheatSheet } from 'app/shared/cheat-sheet/cheat-sheet.model';
+import { FACTORIO_ICONS_INFO } from 'app/shared/factorio-icons.enum';
 
 // Constants
 import { TRAIN_COLOR_DATA } from './train-colors.data';
@@ -21,6 +22,8 @@ export class TrainColorsComponent implements OnInit {
   public displayedData: TrainColor[] = [];
   public generated = false;
   public filterString = '';
+
+  protected readonly FACTORIO_ICONS_INFO = FACTORIO_ICONS_INFO;
 
   constructor(public dataService: DataService) {}
 

--- a/src/app/pipes/replace.pipe.ts
+++ b/src/app/pipes/replace.pipe.ts
@@ -13,3 +13,10 @@ export class ReplacePipe implements PipeTransform {
       .replace(/(^\w|\s\w)/g, (m) => m.toUpperCase());
   }
 }
+
+// TODO: Modify replace function to split on the : symbol and take the second half.
+//
+// const split = value.split(":")
+// const display = split.pop();
+// const result = display ? display.trim() ?? value;
+// return result;


### PR DESCRIPTION
## Changes:

- Add nearly all of the changes suggested in: https://github.com/deniszholob/factorio-cheat-sheet/pull/445#discussion_r2210636611

## Context:

I can't get this bit working:

> then modify replace function to just split on the ":" symbol and take the 2nd half
> 
> ```ts
> const split = value.split(":")
> const display = split.pop();
> const result = display ? display.trim() ?? value;
> return result;
> ```