### PR TITLE
Fix order of SCIENCE_PACK_RATES_TO_TRY items

### DIFF
--- a/src/app/cheat-sheets/game-base/science/science.component.ts
+++ b/src/app/cheat-sheets/game-base/science/science.component.ts
@@ -37,7 +37,7 @@ export class ScienceComponent implements OnInit {
   };
 
   protected SCIENCE_PACK_RATES_TO_TRY: number[] = [
-    75, 150, 60, 120, 240, 600, 1200, 1000,
+    75, 150, 60, 120, 240, 600, 1000, 1200,
   ];
   protected calcScience: LabsCalc = {
     labsRequired: 1,


### PR DESCRIPTION
## Changes

<!-- List your changes. -->

- Resort items in the `SCIENCE_PACK_RATES_TO_TRY` const into proper ascending order.

## Context

Currently the order is `1200` then `1000`. This is confusing, because I expected the biggest number to be at the end of the list. My PR fixes the order, so the biggest number is at the end of the list. 😉 

<!-- Explain why you are making these changes. -->
<!-- Paste screenshots if you are making a visual change to the site. -->
