### PR TITLE
Remove hr element at end of trains component

### DIFF
--- a/src/app/cheat-sheets/game-base/trains/trains.component.html
+++ b/src/app/cheat-sheets/game-base/trains/trains.component.html
@@ -96,7 +96,5 @@
     />
   </div>
 
-  <hr />
-
   <div class="row align-items-center"></div>
 </app-cheat-sheet-template>


### PR DESCRIPTION
## Changes

- Remove `<hr />` element at end of Trains component

## Context

We don't need this extra horizontal line. At the end of the component we should have normal whitespace.